### PR TITLE
LLM module improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,26 @@ entryMain(async (input: InputProps<Arguments>) => {
 })
 ```
 
-### How to build
+## How to build
 
 `bls-sdk-ts build ./index.ts -o <outDirectory> -f <outFile>`
 
 ### Building examples locally
 
 ```sh
-npm run build && node ./dist/bundler build ./examples/llm/index.ts -o ./build -f llm-example.wasm
+npm run build && node ./dist/bundler build ./examples/llm/index.ts -o ./build -f llm-example.wasm --features llm
+```
+
+### Re-install/update Javy and plugins
+
+```sh
+npm run build && node ./dist/bundler build ./examples/crypto/index.ts -o ./build -f crypto-example.wasm --reinstall
+```
+
+Note: `--reinstall` will force the re-installation of Javy and the plugins.
+
+## Uninstall Javy and plugins
+
+```sh
+npm run build && node ./dist/bundler uninstall
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ entryMain(async (input: InputProps<Arguments>) => {
 
 ### Building examples locally
 
+#### Building the LLM example
+
 ```sh
 npm run build && node ./dist/bundler build ./examples/llm/index.ts -o ./build -f llm-example.wasm --features llm
 ```
@@ -62,7 +64,7 @@ npm run build && node ./dist/bundler build ./examples/llm/index.ts -o ./build -f
 ### Re-install/update Javy and plugins
 
 ```sh
-npm run build && node ./dist/bundler build ./examples/crypto/index.ts -o ./build -f crypto-example.wasm --update
+npm run build && node ./dist/bundler build ./examples/fetch/index.ts -o ./build -f fetch-example.wasm --update
 ```
 
 Note: `--update` will force the re-installation of Javy and the plugins - getting the latest versions.
@@ -72,3 +74,12 @@ Note: `--update` will force the re-installation of Javy and the plugins - gettin
 ```sh
 npm run build && node ./dist/bundler uninstall
 ```
+
+## Features
+
+| Feature | Description |
+|---------|------------|
+| `full` | Adds support for all plugins. |
+| `llm` | Adds support for the LLM plugin. |
+| `crypto` | Adds support for the Crypto plugin. |
+| `fetch` | Adds support for the Fetch plugin. |

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ npm run build && node ./dist/bundler build ./examples/llm/index.ts -o ./build -f
 ### Re-install/update Javy and plugins
 
 ```sh
-npm run build && node ./dist/bundler build ./examples/crypto/index.ts -o ./build -f crypto-example.wasm --reinstall
+npm run build && node ./dist/bundler build ./examples/crypto/index.ts -o ./build -f crypto-example.wasm --update
 ```
 
-Note: `--reinstall` will force the re-installation of Javy and the plugins.
+Note: `--update` will force the re-installation of Javy and the plugins - getting the latest versions.
 
 ## Uninstall Javy and plugins
 

--- a/bundler/index.ts
+++ b/bundler/index.ts
@@ -72,9 +72,9 @@ yargs(hideBin(process.argv))
 						return features as SupportedFeature[]
 					}
 				})
-				.option('reinstall', {
+				.option('update', {
 					alias: 'r',
-					describe: 'Force reinstall of Javy and bless plugins',
+					describe: 'Force update of Javy and bless plugins',
 					type: 'boolean',
 					default: false
 				})
@@ -87,7 +87,7 @@ yargs(hideBin(process.argv))
 					argv.outDir,
 					argv.outFile,
 					argv.features || [],
-					argv.reinstall
+					argv.update
 				)
 			} catch (error) {
 				console.error('Error:', error)
@@ -118,13 +118,13 @@ interface SupportedArchitectures {
 
 async function installJavy(
 	javyPath: string,
-	forceReinstall: boolean = false
+	forceUpdate: boolean = false
 ): Promise<void> {
 	if (existsSync(javyPath)) {
-		// Skip installation if already installed and force-reinstall is false
-		if (!forceReinstall) return
+		// Skip installation if already installed and force-update is false
+		if (!forceUpdate) return
 
-		// If force-reinstall is true and file exists, delete it
+		// If force-update is true and file exists, delete it
 		unlinkSync(javyPath)
 	}
 
@@ -177,7 +177,7 @@ async function installJavy(
 async function installJavyBlessPlugins(
 	pluginsPath: string,
 	features: SupportedFeature[],
-	forceReinstall: boolean
+	forceUpdate: boolean
 ): Promise<void> {
 	try {
 		// Fetch release info first to get the tag
@@ -194,15 +194,15 @@ async function installJavyBlessPlugins(
 		const pluginName = `bless-plugins${featuresSuffix}-${latestTag}.wasm`
 		const actualPluginPath = path.join(pluginDir, pluginName)
 
-		// Check if plugin exists and handle reinstall
-		if (existsSync(actualPluginPath) && !forceReinstall) {
+		// Check if plugin exists and handle update
+		if (existsSync(actualPluginPath) && !forceUpdate) {
 			return
 		}
 
 		const installSpinner = ora('Installing Bless plugins ...').start()
 
-		// Remove existing plugin if forcing reinstall
-		if (existsSync(actualPluginPath) && forceReinstall) {
+		// Remove existing plugin if forcing update
+		if (existsSync(actualPluginPath) && forceUpdate) {
 			unlinkSync(actualPluginPath)
 		}
 
@@ -236,7 +236,7 @@ async function runBuildCommand(
 	outDir: string | undefined,
 	outFile: string | undefined,
 	features: SupportedFeature[],
-	reinstall: boolean
+	update: boolean
 ) {
 	// Validate input path
 	if (!existsSync(entry)) {
@@ -270,8 +270,8 @@ async function runBuildCommand(
 		})
 		buildSpinner.succeed('JS build successful.')
 
-		await installJavy(JAVY_PATH, reinstall)
-		await installJavyBlessPlugins(PLUGINS_PATH, features, reinstall)
+		await installJavy(JAVY_PATH, update)
+		await installJavyBlessPlugins(PLUGINS_PATH, features, update)
 
 		let pluginPaths: string[] = []
 		if (existsSync(PLUGINS_DIR)) {

--- a/examples/llm/index.ts
+++ b/examples/llm/index.ts
@@ -26,13 +26,11 @@ interface LlmInstance {
     setOptions(options: LlmOptions): void;
     getOptions(): LlmOptions;
     chat(prompt: string): string;
-    MODELS: ModelsInterface;
 }
 
 // Type definition for the BlessLLM constructor
 interface BlessLLMConstructor {
     (model: string): LlmInstance;
-    MODELS: ModelsInterface;
 }
 
 // Declare the global BlessLLM

--- a/examples/llm/index.ts
+++ b/examples/llm/index.ts
@@ -1,12 +1,58 @@
-declare const BlessLLM: any;
+// Type definitions for the models
+interface ModelQuantization {
+    DEFAULT: string;
+    [key: string]: string;
+}
+
+interface ModelsInterface {
+    LLAMA_3_2_1B: ModelQuantization;
+    LLAMA_3_2_3B: ModelQuantization;
+    MISTRAL_7B: ModelQuantization;
+    MIXTRAL_8X7B: ModelQuantization;
+    GEMMA_2_2B: ModelQuantization;
+    GEMMA_2_7B: ModelQuantization;
+    GEMMA_2_9B: ModelQuantization;
+}
+
+// Type definitions for the options
+interface LlmOptions {
+    system_message: string;
+    temperature?: number;
+    top_p?: number;
+}
+
+// Type definition for the LLM instance
+interface LlmInstance {
+    setOptions(options: LlmOptions): void;
+    getOptions(): LlmOptions;
+    chat(prompt: string): string;
+    MODELS: ModelsInterface;
+}
+
+// Type definition for the BlessLLM constructor
+interface BlessLLMConstructor {
+    (model: string): LlmInstance;
+    MODELS: ModelsInterface;
+}
+
+// Declare the global BlessLLM
+declare const BlessLLM: BlessLLMConstructor;
+declare const MODELS: ModelsInterface;
+
+const supportedModels = JSON.stringify(MODELS, null, 2);
+console.log("Supported Models", supportedModels);
 
 // Create instance
-const llm = BlessLLM("Llama-3.1-8B-Instruct-q4f32_1-MLC");
+const llm = BlessLLM(MODELS.MISTRAL_7B.DEFAULT);
 
 // Set options
 llm.setOptions({
-    system_message: "You are a helpful assistant. First time I ask, your name will be Lucy. Second time I ask, your name will be Bob."
+  system_message: "You are a helpful assistant. First time I ask, your name will be Lucy. Second time I ask, your name will be Bob."
 });
+
+// Get options
+const options = llm.getOptions();
+console.log("Options", JSON.stringify(options, null, 2));
 
 // Chat
 console.log(llm.chat("What is your name?"));


### PR DESCRIPTION
# Changelog

- Updated LLM example to align with host/runtime LLM module
- Updated to the CLI commands:
  - added `--features` option - will install relevant plugin based on specified feature
  - added `--update` option - will force reinstall of Javy and bless plugins from latest release
  - added `uninstall` command - removes Blockless Javy binary and plugins directory
- Updated README with new build and installation instructions

These changes should give flexibility to the build script to compile the JS with specific and/or all plugins - essentially allowing user to optimize the WASM output size (as they now have a choice to explicitly reference in only required plugins).