### PR TITLE
feat: javy plugin version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ npm run build && node ./dist/bundler build ./examples/fetch/index.ts -o ./build 
 ```
 
 #### Update to latest version
-Use `--update` to fetch and install the latest plugin version:
+Use `--update=true` to fetch and install the latest plugin version:
 
 ```sh
-npm run build && node ./dist/bundler build ./examples/fetch/index.ts -o ./build -f fetch-example.wasm --update
+npm run build && node ./dist/bundler build ./examples/fetch/index.ts -o ./build -f fetch-example.wasm --update=true
 ```
 
 #### Use specific version
@@ -95,15 +95,15 @@ You can specify a particular plugin version by providing it as a value to the `-
 
 ```sh
 # Version with 'v' prefix
-npm run build && node ./dist/bundler build ./examples/fetch/index.ts -o ./build -f fetch-example.wasm --update v0.2.3
+npm run build && node ./dist/bundler build ./examples/fetch/index.ts -o ./build -f fetch-example.wasm --update=v0.2.3
 
 # Version without 'v' prefix (will be normalized)
-npm run build && node ./dist/bundler build ./examples/fetch/index.ts -o ./build -f fetch-example.wasm --update 0.2.3
+npm run build && node ./dist/bundler build ./examples/fetch/index.ts -o ./build -f fetch-example.wasm --update=0.2.3
 ```
 
 Note: The `--update` flag will force the re-installation of Javy and the plugins.
-When used without a value, it fetches the latest versions.
 When provided with a version, it will install that specific version.
+When provided with `true`, it will fetch the latest version. When provided with `false`, it will use the pinned version.
 
 ## Uninstall Javy and plugins
 

--- a/bundler/index.ts
+++ b/bundler/index.ts
@@ -178,9 +178,9 @@ async function installJavy(
 			mode: platform === 'win32' ? '755' : '775'
 		})
 
-		installSpinner.succeed('Installation successful.')
+		installSpinner.succeed('Javy installation successful.')
 	} catch (error) {
-		installSpinner.fail('Installation failed.')
+		installSpinner.fail('Javy installation failed.')
 		console.error('Error installing Javy:', error)
 		process.exit(1)
 	}

--- a/bundler/index.ts
+++ b/bundler/index.ts
@@ -125,13 +125,17 @@ async function installJavy(
 ): Promise<void> {
 	if (existsSync(javyPath)) {
 		// Skip installation if already installed and force-update is false
-		if (!forceUpdate) return
+		if (!forceUpdate) {
+			const version = execSync(`${javyPath} --version`).toString().trim().split(' ')[1]
+			console.log(`Javy v${version} already installed. Skipping installation.`)
+			return
+		}
 
 		// If force-update is true and file exists, delete it
 		unlinkSync(javyPath)
 	}
 
-	const installSpinner = ora('Installing dependencies ...').start()
+	const installSpinner = ora('Installing Javy...').start()
 
 	try {
 		// Determine the appropriate Javy binary architecture and filename
@@ -191,7 +195,7 @@ async function installJavyBlessPlugins(
 	features: SupportedFeature[],
 	forceUpdate: boolean,
 	version?: string
-): Promise<string[]> {
+): Promise<{ name: string; path: string }[]> {
 	try {
 		// Use provided version or fetch latest if not specified
 		const targetVersion = version || await fetch(
@@ -203,19 +207,21 @@ async function installJavyBlessPlugins(
 		}
 
 		console.log(`Target plugin version: ${targetVersion}`)
-		const installSpinner = ora(`Installing Bless plugins (${targetVersion})...`).start()
 		const pluginsToInstall = features.length === 0 ? [''] : features
-		const installedPlugins: string[] = []
+		const installedPlugins: { name: string; path: string }[] = []
 
 		for (const feature of pluginsToInstall) {
+			const pluginSpinner = ora(`Installing plugin ${feature}...`).start()
 			const pluginName = feature
 				? `bless-plugins-${feature}-${targetVersion}.wasm`
 				: `bless-plugins-${targetVersion}.wasm`
 			const pluginPath = path.join(pluginsDir, pluginName)
 			const pluginUrl = `https://github.com/blessnetwork/javy-bless-plugins/releases/download/${targetVersion}/${pluginName}`
 
-			if (!existsSync(pluginPath) || forceUpdate) {
-				if (existsSync(pluginPath)) unlinkSync(pluginPath)
+			if (forceUpdate || !existsSync(pluginPath)) {
+				if (existsSync(pluginPath)) {
+					unlinkSync(pluginPath)
+				}
 
 				const response = await fetch(pluginUrl)
 				if (!response.ok) {
@@ -225,13 +231,12 @@ async function installJavyBlessPlugins(
 				}
 
 				fs.writeFileSync(pluginPath, Buffer.from(await response.arrayBuffer()))
+				pluginSpinner.succeed(`Plugin ${pluginName} installed successfully.`)
+			} else {
+				pluginSpinner.succeed(`Plugin ${pluginName} already installed.`)
 			}
-			installedPlugins.push(pluginPath)
+			installedPlugins.push({ name: feature, path: pluginPath })
 		}
-
-		installSpinner.succeed(
-			`Plugins installation successful (${targetVersion}, ${features.length ? `features: ${features.join(', ')}` : 'default plugin'})`
-		)
 		return installedPlugins
 	} catch (error) {
 		console.error('Error installing Bless plugins:', error)
@@ -279,14 +284,22 @@ async function runBuildCommand(
 		buildSpinner.succeed('JS build successful.')
 
 		await installJavy(JAVY_PATH, !!update)
+
 		// Determine which version to use:
 		// 1. If update is a string (specific version), use it (normalize by adding 'v' prefix if needed)
 		// 2. If update is true (without specific version), fetch latest
 		// 3. Otherwise, use the default pinned version
 		let versionToUse: string | undefined
 		if (typeof update === 'string') {
-			// Normalize version format (add 'v' prefix if not present)
-			versionToUse = update.startsWith('v') ? update : `v${update}`
+			// check if update is set to true or false
+			if (update === 'true') {
+				versionToUse = undefined
+			} else if (update === 'false') {
+				versionToUse = DEFAULT_JAVY_BLESS_PLUGINS_VERSION
+			} else {
+				// Normalize version format (add 'v' prefix if not present)
+				versionToUse = update.startsWith('v') ? update : `v${update}`
+			}
 		} else if (update) {
 			// update flag without specific version means get latest
 			versionToUse = undefined // will fetch latest in installJavyBlessPlugins
@@ -306,9 +319,9 @@ async function runBuildCommand(
 		const javySpinner = ora('Building WASM ...').start()
 		try {
 			const pluginArgs = pluginPaths
-				.map((plugin) => `-C plugin=${plugin}`)
+				.map((plugin) => `-C plugin=${plugin.path}`)
 				.join(' ')
-			pluginSpinner.succeed(`WASM plugins loaded [${pluginPaths.length}]`)
+			pluginSpinner.succeed(`WASM plugins loaded [${pluginPaths.map((p) => p.name).join(', ')}]`)
 			const command = `${JAVY_PATH} build ${pluginArgs} ${path.resolve(
         outPath,
         'index.js'


### PR DESCRIPTION
## Description

The `update` flag now pins to specific hardcoded/default version in the SDK (if not specified).
- it supports `true` flag - which updates to latest version (available on release page).
- it supports specific GH release tag

Examples in `README.md`

## AI Description

This pull request introduces updates to the `README.md` and `bundler/index.ts` files to improve plugin installation and version management, enhance user feedback during installation, and refine the handling of plugin paths and metadata. Below are the most significant changes:

### Updates to plugin version management:

* Updated `README.md` to clarify the usage of the `--update` flag, including the distinction between `true` (fetch latest version) and `false` (use pinned version), and normalized the syntax for specifying versions with the `=` operator.

### Enhancements to installation feedback:

* Modified `installJavy` in `bundler/index.ts` to log the installed version of Javy when skipping installation due to `forceUpdate` being `false`. Improved spinner messages for clarity during installation. [[1]](diffhunk://#diff-79aae6efd8cd00a7743bbf30d59e7a195d871c42869289b437afb24ccd6352b7L128-R138) [[2]](diffhunk://#diff-79aae6efd8cd00a7743bbf30d59e7a195d871c42869289b437afb24ccd6352b7L181-R187)

### Improvements to plugin installation:

* Updated `installJavyBlessPlugins` in `bundler/index.ts` to include per-plugin spinners for better visibility into individual plugin installation status. Changed the return type to include both plugin names and paths for better metadata handling. [[1]](diffhunk://#diff-79aae6efd8cd00a7743bbf30d59e7a195d871c42869289b437afb24ccd6352b7L194-R198) [[2]](diffhunk://#diff-79aae6efd8cd00a7743bbf30d59e7a195d871c42869289b437afb24ccd6352b7L206-R224) [[3]](diffhunk://#diff-79aae6efd8cd00a7743bbf30d59e7a195d871c42869289b437afb24ccd6352b7R234-L234)

### Refinements to build command logic:

* Enhanced `runBuildCommand` in `bundler/index.ts` to handle `update` flag values (`true`, `false`, or specific version strings) more robustly and adjusted plugin argument construction to use plugin metadata (`name` and `path`) for better clarity in logs. [[1]](diffhunk://#diff-79aae6efd8cd00a7743bbf30d59e7a195d871c42869289b437afb24ccd6352b7R287-R302) [[2]](diffhunk://#diff-79aae6efd8cd00a7743bbf30d59e7a195d871c42869289b437afb24ccd6352b7L309-R324)